### PR TITLE
A suite of redis memory optimizations

### DIFF
--- a/baw-workers.gemspec
+++ b/baw-workers.gemspec
@@ -39,4 +39,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'resque_solo', '~> 0.1'
   spec.add_runtime_dependency 'resque-status', '~> 0.5'
   spec.add_runtime_dependency 'actionmailer', '~> 4.2'
+  spec.add_runtime_dependency 'redis', '~> 3.2'
 end

--- a/lib/baw-workers.rb
+++ b/lib/baw-workers.rb
@@ -11,6 +11,7 @@ require 'resque'
 require 'resque_solo'
 require 'resque-job-stats'
 require 'resque-status'
+require 'baw-workers/resque_status_custom_expire'
 
 require 'baw-workers/version'
 require 'baw-workers/register_mime_types'
@@ -28,6 +29,8 @@ module BawWorkers
   autoload :Validation, 'baw-workers/validation'
   autoload :ActionBase, 'baw-workers/action_base'
   autoload :ApiCommunicator, 'baw-workers/api_communicator'
+  autoload :RedisCommunicator, 'baw-workers/redis_communicator'
+  autoload :PartialPayload, 'baw-workers/partial_payload'
   autoload :FileInfo, 'baw-workers/file_info'
   autoload :ResqueApi, 'baw-workers/resque_api'
   autoload :ResqueJobId, 'baw-workers/resque_job_id'
@@ -70,6 +73,10 @@ module BawWorkers
     autoload :AudioCache, 'baw-workers/storage/audio_cache'
     autoload :AudioOriginal, 'baw-workers/storage/audio_original'
     autoload :SpectrogramCache, 'baw-workers/storage/spectrogram_cache'
+  end
+
+  module Template
+    autoload :Action, 'baw-workers/template/action'
   end
 
 end

--- a/lib/baw-workers/analysis/payload.rb
+++ b/lib/baw-workers/analysis/payload.rb
@@ -201,13 +201,12 @@ module BawWorkers
           invariant[key] = analysis_params.delete(key)
         end
 
-        # 2. check if invariant payload already exists
-        # 3. if it does, validate it is identical
-        # 4. if it does not, insert it
-
         # e.g. baw-workers:partial_payload:analysis:20-1472601600 (leading namespace added by PartialPayload)
         unique_key = "analysis:" + analysis_params[:job_id].to_s + "-" + group_key
 
+        # 2. check if invariant payload already exists
+        # 3. if it does, validate it is identical
+        # 4. if it does not, insert it
         payload = BawWorkers::PartialPayload.create_or_validate(invariant, unique_key)
 
         # 5. return the lean analysis_params merge with the partial payload key

--- a/lib/baw-workers/analysis/payload.rb
+++ b/lib/baw-workers/analysis/payload.rb
@@ -4,7 +4,8 @@ module BawWorkers
     # Class that handles creating and evaluating analysis payloads.
     class Payload
 
-      OPTS_FIELDS = [
+      # A list of fields invariant to the payload
+      BASE_FIELDS = [
           # command to run, with placeholders
           :command_format,
           # Relative path to executable or script to run.
@@ -22,14 +23,23 @@ module BawWorkers
           :copy_paths,
           # string containing config/settings for executable
           :config,
-          # identifier for job (integer or 'system')
-          :job_id,
 
+          # Paths to nest output results.
+          # Particularly useful for system jobs the can run multiple analysis and store the output in the same folder.
+          :sub_folders
+      ]
+
+      # The full list of fields expected in the payload
+      OPTS_FIELDS = BASE_FIELDS + [
           # audio recording info
           :uuid,
           :id,
           :datetime_with_offset,
-          :original_format
+          :original_format,
+
+          # identifier for job (integer or 'system')
+          # This field is invariant, but its also useful as a PK so we keep it anyway
+          :job_id
       ]
 
       COMMAND_PLACEHOLDERS = [
@@ -174,6 +184,34 @@ module BawWorkers
         normalised_keys = BawWorkers::Validation.deep_symbolize_keys(opts)
         BawWorkers::Validation.check_custom_hash(normalised_keys, BawWorkers::Analysis::Payload::OPTS_FIELDS)
         normalised_keys
+      end
+
+      # Split apart the variant and invariant parts of the payload.
+      # @param [Hash] analysis_params
+      # @param [String] group_key
+      def self.validate_and_create_invariant_opts(analysis_params, group_key)
+        # 0. verify group key
+        return analysis_params if group_key.blank?
+
+        # 1. split out invariant keys
+        invariant = {}
+        BASE_FIELDS.each do |key|
+          raise "analysis_params is missing required key #{key}" unless analysis_params.has_key?(key)
+
+          invariant[key] = analysis_params.delete(key)
+        end
+
+        # 2. check if invariant payload already exists
+        # 3. if it does, validate it is identical
+        # 4. if it does not, insert it
+
+        # e.g. baw-workers:partial_payload:analysis:20-1472601600 (leading namespace added by PartialPayload)
+        unique_key = "analysis:" + analysis_params[:job_id].to_s + "-" + group_key
+
+        payload = BawWorkers::PartialPayload.create_or_validate(invariant, unique_key)
+
+        # 5. return the lean analysis_params merge with the partial payload key
+        payload.merge(analysis_params)
       end
 
     end

--- a/lib/baw-workers/exceptions.rb
+++ b/lib/baw-workers/exceptions.rb
@@ -10,5 +10,6 @@ module BawWorkers
     class HarvesterEndpointError < HarvesterError; end
     class HarvesterAnalysisError < HarvesterError; end
     class AnalysisCacheError < StandardError; end
+    class PartialPayloadMissing < StandardError; end
   end
 end

--- a/lib/baw-workers/exceptions.rb
+++ b/lib/baw-workers/exceptions.rb
@@ -10,6 +10,5 @@ module BawWorkers
     class HarvesterEndpointError < HarvesterError; end
     class HarvesterAnalysisError < HarvesterError; end
     class AnalysisCacheError < StandardError; end
-    class PartialPayloadMissing < StandardError; end
   end
 end

--- a/lib/baw-workers/harvest/action.rb
+++ b/lib/baw-workers/harvest/action.rb
@@ -203,6 +203,14 @@ module BawWorkers
         ['harvest_params']
       end
 
+      # Produces a sensible name for this payload.
+      # Should be unique but does not need to be. Has no operational effect.
+      # This value is only used when the status is updated by resque:status.
+      def name
+        hp = @options[:harvest_params]
+        "Harvest for: #{hp[:file_name]}, size=#{hp[:size]}, site_id=#{hp[:site_id]}"
+      end
+
     end
   end
 end

--- a/lib/baw-workers/media/action.rb
+++ b/lib/baw-workers/media/action.rb
@@ -123,8 +123,22 @@ module BawWorkers
 
       end
 
+      #
+      # Instance methods
+      #
+
+      # List of keys to pull out of options/payload hash.
+      # @return [Array<String>]
       def perform_options_keys
         %w(media_type media_request_params)
+      end
+
+      # Produces a sensible name for this payload.
+      # Should be unique but does not need to be. Has no operational effect.
+      # This value is only used when the status is updated by resque:status.
+      def name
+        mrp = @options['media_request_params']
+        "Media request: #{@options['media_type']}, [#{mrp['start_offset']}-#{mrp['end_offset']}), format:#{mrp['format']}}"
       end
 
     end

--- a/lib/baw-workers/mirror/action.rb
+++ b/lib/baw-workers/mirror/action.rb
@@ -79,6 +79,13 @@ module BawWorkers
         %w(source destinations)
       end
 
+      # Produces a sensible name for this payload.
+      # Should be unique but does not need to be. Has no operational effect.
+      # This value is only used when the status is updated by resque:status.
+      def name
+        "Mirroring from:#{@options['source']}, to: #{@options['destinations']}"
+      end
+
     end
   end
 end

--- a/lib/baw-workers/partial_payload.rb
+++ b/lib/baw-workers/partial_payload.rb
@@ -1,0 +1,151 @@
+module BawWorkers
+
+  class PartialPayloadMissing < StandardError;
+  end
+
+  class InconsistentBasePayload < StandardError;
+  end
+
+  # Stores Redis string payloads in multiple parts.
+  # Useful for splitting apart large payloads that are stuck in, for example, Redis LISTs.
+  # In the common scenario of using a LIST to store job payloads for a processing system, the large invariant parts
+  # of payloads can be split apart and stored separately. We experience 92-96% less memory usage using this technique
+  # on very large payloads for large job sets (e.g. 1000 or more).
+  # This technique should be used when you have at least 100 payloads which are largely identical.
+  class PartialPayload
+    @communicator = BawWorkers::Config.redis_communicator
+
+    class << self
+      PARTIAL_PAYLOAD_KEY = "payload_base"
+      REDIS_NAMESPACE = "partial_payload"
+      BASE_PAYLOAD_EXPIRE = 86400 * 365 # 1 year
+
+
+      # Store a base payload that should be merged with a partial payload.
+      # See the tests for clear examples.
+      # @param [Hash] base_payload - they base payload to store
+      # @param [Object] key - a unique key used to retrieve the payload
+      # @return [Hash] a partial payload hashed. This hash should be merged with your actual payload.
+      def create(base_payload, key)
+        key = add_namespace(key)
+
+        # set a very long expire. We don't care if these payloads exist for a very long time.
+        out_opts = {
+            expire_seconds: BASE_PAYLOAD_EXPIRE
+        }
+        success = @communicator.set(key, base_payload, out_opts)
+
+        raise 'PartialPayload creation failed' unless success
+
+        # return a hash with the absolute redis_key that can be used to retrieve the base payload
+        {PARTIAL_PAYLOAD_KEY.to_sym => out_opts[:key]}
+      end
+
+      # Store a base payload that should be merged with a partial payload, OR if it already exists, validates that the
+      # two payloads are identical.
+      # @param [Hash] base_payload - they base payload to store
+      # @param [Object] key - a unique key used to retrieve the payload
+      # @return [Hash] a partial payload hashed. This hash should be merged with your actual payload.
+      def create_or_validate(base_payload, key)
+        existing_base = get(key)
+        if existing_base
+          raise InconsistentBasePayload if existing_base != BawWorkers::ResqueJobId::normalise(base_payload)
+
+          # return a hash with the absolute redis_key that can be used to retrieve the base payload
+          {PARTIAL_PAYLOAD_KEY.to_sym => @communicator.add_namespace(add_namespace(key))}
+        else
+          create(base_payload, key)
+        end
+      end
+
+      # Reconstruct a payload by combining a partial payload with its base payload.
+      # resolve can reconstruct several nested payload partials via recursion. Its only limitations
+      # are callstack size and Redis performance.
+      # Payloads that are not hashes or are hashes without the partial payload key, are ignored and returned unmodified.
+      # @param [Hash] payload
+      # @return [Hash] the reconstructed payload
+      def resolve(payload)
+        return payload unless payload.is_a?(Hash)
+
+        has_string = payload.has_key?(PARTIAL_PAYLOAD_KEY)
+        has_symbol = payload.has_key?(PARTIAL_PAYLOAD_KEY.to_sym)
+        if has_string || has_symbol
+          # we assume the full redis key (with namespaces) has been stored
+          redis_key = payload.delete(has_string ? PARTIAL_PAYLOAD_KEY : PARTIAL_PAYLOAD_KEY.to_sym)
+
+
+          base = @communicator.get(redis_key, {no_namespace: true})
+
+          if base.nil?
+            raise PartialPayloadMissing.new("Could not retrieve partial payload `#{redis_key}`")
+          end
+
+          # RECURSIVE - allow the base payload to have its own base payload
+          new_base = resolve(base)
+
+          payload = new_base.merge(payload)
+        end
+
+        payload
+      end
+
+      # Gets a base payload if it exists
+      # @param [String] key - they key for the base payload to retrieve
+      # @return [Hash] returns a Hash if found, otherwise nil
+      def get(key)
+        key = add_namespace(key)
+        @communicator.get(key)
+      end
+
+      # Delete the base payload.
+      # Does not cascade and delete other linked base payloads.
+      # @param [String] key - they key to delete
+      # @return [Boolean] True if the delete succeeded.
+      def delete(key)
+        key = add_namespace(key)
+
+        @communicator.delete(key)
+      end
+
+      # Delete the base payload.
+      # *Does* cascade and delete other linked base payloads.
+      # Throws `PartialPayloadMissing` if a linked base payload can not be found.
+      # @param [String] key - they key to delete
+      # @return [Boolean] True if the delete succeeded.
+      def delete_recursive(key)
+        has_namespace = key.include?(':' + REDIS_NAMESPACE + ':')
+        key = add_namespace(key) unless has_namespace
+
+        # first get the partial payload
+        partial = @communicator.get(key, {no_namespace: has_namespace})
+
+        if partial.nil?
+          raise PartialPayloadMissing.new("Could not retrieve partial payload `#{key}`")
+        end
+
+        # now recurse through linked list
+        has_key = has_base_payload(partial)
+        if has_key
+          # RECURSIVE - allow the base payload to have its own base payload
+          delete_recursive(partial[has_key])
+        end
+
+        # finally delete
+        @communicator.delete(key, {no_namespace: has_namespace})
+      end
+
+      private
+
+      def has_base_payload(hash)
+        return PARTIAL_PAYLOAD_KEY if hash.has_key?(PARTIAL_PAYLOAD_KEY)
+        return PARTIAL_PAYLOAD_KEY.to_sym if hash.has_key?(PARTIAL_PAYLOAD_KEY.to_sym)
+
+        nil
+      end
+
+      def add_namespace(key)
+        REDIS_NAMESPACE + ':' + key
+      end
+    end
+  end
+end

--- a/lib/baw-workers/redis_communicator.rb
+++ b/lib/baw-workers/redis_communicator.rb
@@ -1,0 +1,122 @@
+module BawWorkers
+  class DecodeException < StandardError;
+  end
+
+  class RedisCommunicator
+
+    attr_accessor :logger
+
+    # Create a new BawWorkers::ApiCommunicator.
+    # @param [Object] logger
+    # @param [Object] redis_instance
+    # @param [Object] settings
+    # @return [BawWorkers::RedisCommunicator]
+    def initialize(logger, redis_instance, settings = {})
+      @logger = logger
+      @redis = redis_instance
+      @settings = settings
+
+      @class_name = self.class.name
+    end
+
+    def namespace
+      @settings[:namespace] || 'baw-workers'
+    end
+
+    def add_namespace(key)
+      namespace + ':' + key
+    end
+
+    def redis
+      @redis
+    end
+
+
+    # @param [String] key
+    # @return [Boolean]
+    def delete(key, opts = {})
+      key = add_namespace(key) unless opts[:no_namespace]
+
+      deleted = @redis.del(key)
+
+      raise 'Too many keys deleted' if deleted > 1
+
+      deleted == 1
+    end
+
+    # @param [String] key
+    # @param [Hash] opts
+    # @return [Boolean]
+    def exists(key, opts = {})
+      key = add_namespace(key) unless opts[:no_namespace]
+
+      @redis.exists(key)
+    end
+
+    # @param [String] key
+    # @return [Hash]
+    def get(key, opts = {})
+      key = add_namespace(key) unless opts[:no_namespace]
+
+      value = @redis.get(key)
+      decode(value)
+    end
+
+    # Set the redis string with to assigned value
+    # @param [Object] value
+    # @param [String] key
+    # @return [Boolean]
+    # @param [Hash] opts
+    def set(key, value, opts = {})
+      key = add_namespace(key) unless opts[:no_namespace]
+
+      opts[:key] = key
+
+      set_opts = {}
+      set_opts[:ex] = opts[:expire_seconds] if opts[:expire_seconds]
+      result = @redis.set(key, encode(value), set_opts)
+
+      boolify(result)
+    end
+
+
+    # Given a Ruby object, returns a string suitable for storage in a
+    # queue.
+    # Blatantly lifted from: https://github.com/resque/resque/blob/d0e187881e02d852f8e4755aef3c14319636527b/lib/resque.rb#L30
+    def encode(object)
+      if MultiJson.respond_to?(:dump) && MultiJson.respond_to?(:load)
+        MultiJson.dump object
+      else
+        MultiJson.encode object
+      end
+    end
+
+    # Given a string, returns a Ruby object.
+    # Blatantly lifted from: https://github.com/resque/resque/blob/d0e187881e02d852f8e4755aef3c14319636527b/lib/resque.rb#L44
+    def decode(object)
+      return unless object
+
+      begin
+        if MultiJson.respond_to?(:dump) && MultiJson.respond_to?(:load)
+          MultiJson.load object
+        else
+          MultiJson.decode object
+        end
+      rescue ::MultiJson::DecodeError => e
+        raise DecodeException, e.message, e.backtrace
+      end
+    end
+
+    private
+
+    def boolify(value)
+      if value && value.is_a?(String) && 'OK' == value
+        true
+      else
+        false
+      end
+    end
+
+
+  end
+end

--- a/lib/baw-workers/redis_communicator.rb
+++ b/lib/baw-workers/redis_communicator.rb
@@ -31,7 +31,7 @@ module BawWorkers
       @redis
     end
 
-
+    # Delete a single key.
     # @param [String] key
     # @return [Boolean]
     def delete(key, opts = {})
@@ -39,6 +39,8 @@ module BawWorkers
 
       deleted = @redis.del(key)
 
+      # Technically the server could delete multiple keys. Since we consider this undefined behaviour at this point
+      # in time we throw. In the future we may support deleting multiple keys.
       raise 'Too many keys deleted' if deleted > 1
 
       deleted == 1

--- a/lib/baw-workers/resque_api.rb
+++ b/lib/baw-workers/resque_api.rb
@@ -257,12 +257,26 @@ module BawWorkers
       end
 
       # Get a Resque::Status hash for the matching action job and payload.
+      # Required when you need to regenerate a deterministic key.
       # @param [Class] action_class
       # @param [Hash] args
       # @return [Resque::Plugins::Status::Hash] status
       def status(action_class, args = {})
         job_id = BawWorkers::ResqueJobId.create_id_props(action_class, args)
         Resque::Plugins::Status::Hash.get(job_id)
+      end
+
+      # Get a Resque::Status hash for the provided unique key.
+      # @param [String] unique_key - the key that uniquely identifies this action. Typically a uuid.
+      # @return [Resque::Plugins::Status::Hash] status
+      def status_by_key(unique_key)
+        Resque::Plugins::Status::Hash.get(unique_key)
+      end
+
+      # Get a resque:status' key expire time
+      def status_ttl(unique_key)
+        key = Resque::Plugins::Status::Hash.status_key(unique_key)
+        Resque::Plugins::Status::Hash.redis.ttl(key)
       end
 
     end

--- a/lib/baw-workers/resque_job_id.rb
+++ b/lib/baw-workers/resque_job_id.rb
@@ -4,6 +4,7 @@ module BawWorkers
     class << self
 
       # Create a payload with an id based on the class and args.
+      # WARNING: The order of of values in args is important.
       # @param [String] klass
       # @param [Hash] args
       # @return [Hash] payload
@@ -14,6 +15,7 @@ module BawWorkers
       end
 
       # Get an id from payload (name of class, args hash).
+      # WARNING: The order of of values in args is important.
       # @param [Hash] payload
       # @return [String] id
       def create_id_payload(payload)
@@ -24,6 +26,7 @@ module BawWorkers
       end
 
       # Create an id from class and args.
+      # WARNING: The order of of values in args is important.
       # @param [String] klass
       # @param [Hash] args
       # @return [String] id
@@ -75,8 +78,14 @@ module BawWorkers
       # @param [Array<Hash, Object>] args
       # @return [String] unique id
       def generate(klass, args = [])
+
+        # HACK: I don't know what this ever sorts, but it is important that it doesn't work - sometimes
         args.map! do |arg|
-          arg.is_a?(Hash) ? arg.sort : arg
+          if arg.is_a?(Hash) then
+            arg.sort
+          else
+            arg
+          end
         end
 
         # payload must not include id itself - otherwise id will not match

--- a/lib/baw-workers/resque_status_custom_expire.rb
+++ b/lib/baw-workers/resque_status_custom_expire.rb
@@ -1,0 +1,35 @@
+# A monkey patch for resque status
+module Resque
+  module Plugins
+    module Status
+      EXPIRE_STATUSES = [
+          Resque::Plugins::Status::STATUS_COMPLETED,
+          Resque::Plugins::Status::STATUS_FAILED,
+          Resque::Plugins::Status::STATUS_KILLED,
+      ]
+
+      class Hash
+
+        # set a status by UUID. <tt>messages</tt> can be any number of strings or hashes
+        # that are merged in order to create a single status.
+        # WARNING: MONKEY PATCH
+        # https://github.com/quirkey/resque-status/blob/11eb130ad1bc9cbc11aae3bad4d507ee06f5bb0a/lib/resque/plugins/status/hash.rb
+        # Now only sets a TTL IFF status is in the expire list. Thus the status key
+        # has no expire until it has completed/failed/killed.
+        def self.set(uuid, *messages)
+          val = Resque::Plugins::Status::Hash.new(uuid, *messages)
+          redis.set(status_key(uuid), encode(val))
+
+          # only set the TTL if the job has finished
+          if expire_in && EXPIRE_STATUSES.include?(val['status'])
+            redis.expire(status_key(uuid), expire_in)
+          end
+
+          val
+        end
+
+
+      end
+    end
+  end
+end

--- a/lib/baw-workers/template/action.rb
+++ b/lib/baw-workers/template/action.rb
@@ -1,0 +1,69 @@
+module BawWorkers
+  module Template
+    # demonstrates how to create a minimal worker that adheres to our required behaviors
+    class Action < BawWorkers::ActionBase
+
+      NAME = 'template'
+
+      # These methods do not require a class instance.
+      class << self
+
+        # Get the queue for this action. Used by Resque.
+        # @return [Symbol] The queue.
+        def queue
+          settings = BawWorkers::Settings.actions['template']
+          settings.nil? ? (NAME + '_default') : settings.queue
+        end
+
+        # Perform work! Callstack: Resque->ActionBase::perform->Action::action_perform.
+        # @param [Hash] params
+        # @return [Hash] result information
+        def action_perform(params)
+
+          BawWorkers::Config.logger_worker.info(logger_name) {
+            "Started #{NAME} action using '#{params}'."
+          }
+
+          # DO WORK!
+        end
+
+        # Enqueue a payload.
+        # @param [Hash] template_params - the payload
+        # @return [Boolean] True if job was queued, otherwise false. +nil+
+        #   if the job was rejected by a before_enqueue hook.
+        def action_enqueue(template_params)
+          # call the resque-status create method
+          result = BawWorkers::Template::Action.create(template_params: template_params)
+
+          BawWorkers::Config.logger_worker.info(logger_name) {
+            "Job enqueue returned '#{result}' using #{template_params}."
+          }
+
+          result
+        end
+      end
+
+      #
+      # Instance methods
+      #
+
+
+      # Get the keys for the action_perform options hash.
+      # order is important
+      # List of keys to pull out of options/payload hash.
+      # @return [Array<String>]
+      def perform_options_keys
+        ['template_params']
+      end
+
+      # Produces a sensible name for this payload.
+      # Should be unique but does not need to be. Has no operational effect.
+      # This value is only used when the status is updated by resque:status.
+      def name
+        "#{NAME}:#{@uuid}"
+      end
+
+    end
+  end
+end
+

--- a/lib/settings/settings.default.yml
+++ b/lib/settings/settings.default.yml
@@ -1,14 +1,18 @@
 settings:
+  redis:
+    namespace: 'baw-workers'
+    # http://www.rubydoc.info/github/redis/redis-rb/Redis#initialize-instance_method
+    connection: &redis_config
+      host: localhost
+      port: 6379
+      password: password
+      db: 0
   resque:
     # queues_to_process is only needed when running a Resque worker to
     # specify the Resque queues to watch.
     queues_to_process:
       - example
-    connection:
-        host: localhost
-        port: 6379
-        password: password
-        db: 0
+    connection: *redis_config
     namespace: resque
     log_level: 'Logger::INFO'
     polling_interval_seconds: 5

--- a/spec/lib/baw-workers/analysis/payload_spec.rb
+++ b/spec/lib/baw-workers/analysis/payload_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 
+# test payload splitting with partial payload method
 describe BawWorkers::Analysis::Payload do
   include_context 'shared_test_helpers'
 
@@ -7,6 +8,152 @@ describe BawWorkers::Analysis::Payload do
     BawWorkers::Analysis::Payload.new(BawWorkers::Config.logger_worker)
   }
 
+  let(:analysis_params) {
+    {
+        command_format: '<{file_executable}> "analysis_type -source <{file_source}> -config <{file_config}> -output <{dir_output}> -tempdir <{dir_temp}>"',
+        config: 'blah a very long and repeated blob of text' * 300,
+        file_executable: 'echo',
+        copy_paths: [],
+
+        uuid: 'f7229504-76c5-4f88-90fc-b7c3f5a8732e',
+        id: 123456,
+        datetime_with_offset: '2014-11-18T16:05:00Z',
+        original_format: 'wav',
+
+        job_id: 20,
+        sub_folders: ['hello', 'here_i_am']
+    }
+  }
+
+  let(:analysis_params2) {
+    {
+        command_format: '<{file_executable}> "analysis_type -source <{file_source}> -config <{file_config}> -output <{dir_output}> -tempdir <{dir_temp}>"',
+        config: 'blah a very long and repeated blob of text' * 300,
+        file_executable: 'echo',
+        copy_paths: [],
+
+        uuid: '146d4563-18e7-4aea-ab46-bce5c69dc68c',
+        id: 654321,
+        datetime_with_offset: '2014-11-19T16:05:00Z',
+        original_format: 'wav',
+
+        job_id: 20,
+        sub_folders: ['hello', 'here_i_am']
+    }
+  }
+
+  let(:expected_payload) {
+    {
+        "class" => "BawWorkers::Analysis::Action",
+        "args" => [
+            '7f3600c1257e4a334f759d9f4de2629e',
+            {
+                "analysis_params" =>
+                    {
+                        'payload_base' => 'baw-workers:partial_payload:analysis:20-1471651200',
+                        "uuid" => "f7229504-76c5-4f88-90fc-b7c3f5a8732e",
+                        "id" => 123456,
+                        "datetime_with_offset" => "2014-11-18T16:05:00Z",
+                        "original_format" => "wav",
+                        "job_id" => 20,
+                    }
+            }
+        ]
+    }
+  }
+
+  let(:expected_payload2) {
+    {
+        "class" => "BawWorkers::Analysis::Action",
+        "args" => [
+            '9bbcedbfa382f507a8f9209500dd4486',
+            {
+                "analysis_params" =>
+                    {
+                        'payload_base' => 'baw-workers:partial_payload:analysis:20-1471651200',
+                        "uuid" => "146d4563-18e7-4aea-ab46-bce5c69dc68c",
+                        "id" => 654321,
+                        "datetime_with_offset" => "2014-11-19T16:05:00Z",
+                        "original_format" => "wav",
+                        "job_id" => 20,
+                    }
+            }
+        ]
+    }
+  }
+
+  let(:partial_payload) {
+    {
+
+        "command_format" =>
+            "<{file_executable}> \"analysis_type -source <{file_source}> -config <{file_config}> -output <{dir_output}> -tempdir <{dir_temp}>\"",
+        "sub_folders" => ['hello', 'here_i_am'],
+        "config" => 'blah a very long and repeated blob of text' * 300,
+        "file_executable" => "echo",
+        "copy_paths" => []
+
+    }
+  }
 
 
+  it 'stores and retrieves partial payloads' do
+    queue_name = BawWorkers::Settings.actions.analysis.queue
+
+    # set up
+    expect(Resque.size(queue_name)).to eq(0)
+
+    # enqueue two jobs... we expect two small payloads and one partial payload
+    group_key = Date.new(2016, 8, 20).to_time.to_i.to_s
+    result1 = BawWorkers::Analysis::Action.action_enqueue(analysis_params, group_key)
+    result2 = BawWorkers::Analysis::Action.action_enqueue(analysis_params2, group_key)
+    expect(Resque.size(queue_name)).to eq(2)
+    expect(result1).to be_a(String)
+    expect(result2).to be_a(String)
+    expect(result1.size).to eq(32)
+    expect(result2.size).to eq(32)
+
+
+    found1 = BawWorkers::ResqueApi.jobs_of_with(
+        BawWorkers::Analysis::Action,
+        expected_payload['args'][1])
+    found2 = BawWorkers::ResqueApi.jobs_of_with(
+        BawWorkers::Analysis::Action,
+        expected_payload2['args'][1])
+
+    expect(found1.size).to eq(1)
+    expect(found2.size).to eq(1)
+    expect(found1[0]['class']).to eq(BawWorkers::Analysis::Action.to_s)
+    expect(found2[0]['class']).to eq(BawWorkers::Analysis::Action.to_s)
+    expect(found1[0]['queue']).to eq(queue_name)
+    expect(found2[0]['queue']).to eq(queue_name)
+    expect(found1[0]['args'].size).to eq(2)
+    expect(found2[0]['args'].size).to eq(2)
+    expect(found1[0]['args'][1]).to eq(expected_payload['args'][1])
+    expect(found2[0]['args'][1]).to eq(expected_payload2['args'][1])
+
+    # ensure the partial payload exists and is correct
+    result = BawWorkers::PartialPayload.get("analysis:20-" + group_key)
+    expect(result).to_not be_nil
+    expect(result).to eq(partial_payload)
+
+
+    # ensure entire payload is reconstituted by the time it gets to `action_perform`
+    expect(BawWorkers::Analysis::Action).to receive(:action_perform).with(analysis_params.stringify_keys)
+
+    # prepare audio file
+    target_file = audio_original.possible_paths({
+                                                    uuid: 'f7229504-76c5-4f88-90fc-b7c3f5a8732e',
+                                                    id: 123456,
+                                                    datetime_with_offset: Time.zone.parse('"2014-11-18T16:05:00Z'),
+                                                    original_format: 'wav'
+                                                })[1]
+    FileUtils.mkpath(File.dirname(target_file))
+    FileUtils.cp(audio_file_mono, target_file)
+
+
+    # dequeue and run a job
+    was_run = emulate_resque_worker(BawWorkers::Analysis::Action.queue)
+
+    expect(was_run).to eq(true)
+  end
 end

--- a/spec/lib/baw-workers/partial_payload_spec.rb
+++ b/spec/lib/baw-workers/partial_payload_spec.rb
@@ -21,7 +21,7 @@ describe BawWorkers::RedisCommunicator do
   it 'can create or validate and existing base payload' do
     # important: after the first create, the last 4 will be validation, this `create` should
     # have only been called once.
-    BawWorkers::PartialPayload.should_receive(:create).at_most(:once).and_call_original
+    expect(BawWorkers::PartialPayload).to receive(:create).at_most(:once).and_call_original
 
     (1..5).each do
       result = BawWorkers::PartialPayload.create_or_validate({a: 1, b: 2, c: 3}, 'analysis_job:123')

--- a/spec/lib/baw-workers/partial_payload_spec.rb
+++ b/spec/lib/baw-workers/partial_payload_spec.rb
@@ -1,0 +1,127 @@
+require 'spec_helper'
+
+# noinspection RubyStringKeysInHashInspection
+describe BawWorkers::RedisCommunicator do
+  include_context 'shared_test_helpers'
+
+  let (:redis) { BawWorkers::Config.redis_communicator }
+
+  #let(:fake_redis) { Redis.new }
+
+  it 'adds a key to redis when a partial payload is created' do
+    result = BawWorkers::PartialPayload.create({a: 1, b: 2, c: 3}, 'analysis_job:123')
+
+    expect(redis.exists('partial_payload:analysis_job:123')).to eq(true)
+
+    expect(result.has_key?(:payload_base))
+    expect(result[:payload_base]).to eq('baw-workers:partial_payload:analysis_job:123')
+  end
+
+
+  it 'can create or validate and existing base payload' do
+    # important: after the first create, the last 4 will be validation, this `create` should
+    # have only been called once.
+    BawWorkers::PartialPayload.should_receive(:create).at_most(:once).and_call_original
+
+    (1..5).each do
+      result = BawWorkers::PartialPayload.create_or_validate({a: 1, b: 2, c: 3}, 'analysis_job:123')
+
+      expect(redis.exists('partial_payload:analysis_job:123')).to eq(true)
+
+      expect(result.has_key?(:payload_base))
+      expect(result[:payload_base]).to eq('baw-workers:partial_payload:analysis_job:123')
+    end
+  end
+
+  it 'can create or validate and will fail if existing payload does not match' do
+    result = BawWorkers::PartialPayload.create_or_validate({a: 1, b: 2, c: 3}, 'analysis_job:123')
+
+    expect {
+      result = BawWorkers::PartialPayload.create_or_validate({a: 1, b: 2, c: 4}, 'analysis_job:123')
+    }.to raise_error(BawWorkers::InconsistentBasePayload)
+  end
+
+
+  it 'can remove payloads from redis' do
+    BawWorkers::PartialPayload.create({a: 1, b: 2, c: 3}, 'analysis_job:123')
+
+    expect(redis.exists('partial_payload:analysis_job:123')).to eq(true)
+
+    BawWorkers::PartialPayload.delete('analysis_job:123')
+
+    expect(redis.exists('partial_payload:analysis_job:123')).to eq(false)
+  end
+
+  it 'can resolve a payload' do
+    # store base payload
+    BawWorkers::PartialPayload.create({a: 1, b: 2, c: 3}, 'analysis_job:123')
+
+    # 'dequeue' payload with reference to base payload
+    # noinspection RubyStringKeysInHashInspection
+    payload = {'d' => 4, 'e' => 5, 'f' => 6, 'payload_base' => 'baw-workers:partial_payload:analysis_job:123'}
+
+    resolved_payload = BawWorkers::PartialPayload.resolve(payload)
+
+    expect(resolved_payload).to eq({a: 1, b: 2, c: 3, d: 4, e: 5, f: 6}.stringify_keys)
+  end
+
+  it 'will do nothing if no payload key is found' do
+    # store base payload
+    BawWorkers::PartialPayload.create({a: 1, b: 2, c: 3}, 'analysis_job:123')
+
+    # 'dequeue' payload with reference to base payload
+    payload = {d: 4, e: 5, f: 6}.stringify_keys
+
+    resolved_payload = BawWorkers::PartialPayload.resolve(payload)
+
+    expect(resolved_payload).to eq({d: 4, e: 5, f: 6}.stringify_keys)
+    # it should be the same instance!
+    expect(resolved_payload).to equal(payload)
+  end
+
+  it 'can recursively resolve payloads' do
+
+    result = {}
+    (1..10).each do |index|
+      # store each base payload - with the previous key
+      result = BawWorkers::PartialPayload.create({'value_' + index.to_s => index}.merge(result), "analysis_job:#{index}")
+    end
+
+    # 'dequeue' payload with reference to base payload
+    payload = {'final' => 'concrete', payload_base: 'baw-workers:partial_payload:analysis_job:10'}
+
+    resolved_payload = BawWorkers::PartialPayload.resolve(payload)
+
+    # noinspection RubyStringKeysInHashInspection
+    expect(resolved_payload).to eq({'value_1' => 1, 'value_2' => 2, 'value_3' => 3, 'value_4' => 4,
+                                    'value_5' => 5, 'value_6' => 6, 'value_7' => 7, 'value_8' => 8,
+                                    'value_9' => 9, 'value_10' => 10, 'final' => 'concrete'})
+  end
+
+  it 'can recursively delete partial payloads' do
+
+    result = {}
+    items = (1..10)
+
+    items.each do |index|
+      # store each base payload - with the previous key
+      result = BawWorkers::PartialPayload.create({'value_' + index.to_s => index}.merge(result), "analysis_job:#{index}")
+    end
+
+    # check they exist
+    items.each do |item|
+      expect(redis.exists("partial_payload:analysis_job:#{item}")).to eq(true)
+    end
+
+    # decide we don't wan't the partial payloads
+    result = BawWorkers::PartialPayload.delete_recursive("analysis_job:#{10}")
+    expect(result).to eq(true)
+
+    # check all items do not exist
+    items.each do |item|
+      expect(redis.exists("partial_payload:analysis_job:#{item}")).to eq(false)
+    end
+
+  end
+
+end

--- a/spec/lib/baw-workers/partial_payload_spec.rb
+++ b/spec/lib/baw-workers/partial_payload_spec.rb
@@ -38,7 +38,7 @@ describe BawWorkers::RedisCommunicator do
 
     expect {
       result = BawWorkers::PartialPayload.create_or_validate({a: 1, b: 2, c: 4}, 'analysis_job:123')
-    }.to raise_error(BawWorkers::InconsistentBasePayload)
+    }.to raise_error(BawWorkers::InconsistentBasePayloadError)
   end
 
 

--- a/spec/lib/baw-workers/redis_communicator_spec.rb
+++ b/spec/lib/baw-workers/redis_communicator_spec.rb
@@ -1,0 +1,97 @@
+require 'spec_helper'
+
+describe BawWorkers::RedisCommunicator do
+  include_context 'shared_test_helpers'
+
+  let (:redis) { BawWorkers::Config.redis_communicator  }
+
+  let(:fake_redis) { Redis.new }
+
+  context 'wraps a basic redis API' do
+
+    it 'should wrap keys in a namespace' do
+      redis.set("abc", 123)
+
+      expect(fake_redis.exists("baw-workers:abc")).to eq(true)
+    end
+
+    it 'should allow the key namespace to be configurable' do
+      redis = BawWorkers::RedisCommunicator.new(
+          BawWorkers::Config.logger_worker,
+          fake_redis,
+          {namespace: 'boogey-monster'})
+
+      redis.set("123", "abc")
+
+      expect(fake_redis.exists('boogey-monster:123')).to eq(true)
+    end
+
+    it 'wraps the SET command' do
+
+      success = redis.set('my_object', {test: {nested_hash: 123}, string: 'test'})
+
+      expect(success).to eq(true)
+      expect(fake_redis.get('baw-workers:my_object')).to eq('{"test":{"nested_hash":123},"string":"test"}')
+    end
+
+    it 'wraps the SET command - and can set an expire' do
+      out_opts = {expire_seconds: 7200}
+      success = redis.set('my_object', {test: {nested_hash: 123}, string: 'test'}, out_opts)
+
+      expect(success).to eq(true)
+      expect(fake_redis.ttl('baw-workers:my_object')).to eq(7200)
+    end
+
+    it 'returns the full key in opts' do
+      out_opts = {}
+      success = redis.set('my_object', {test: 'test'}, out_opts)
+
+      expect(success).to eq(true)
+      expect(out_opts[:key]).to eq('baw-workers:my_object')
+    end
+
+    it 'wraps the GET command' do
+      payload = {'media_type' =>"spectrogram", 'media_request_params' =>{'uuid' =>"12140a87-a8df-4a79-ad06-126c6a390110", 'format' =>"png", 'media_type' =>"image/png", 'start_offset' =>18363.0, 'end_offset' =>18371.0, 'channel' =>0, 'sample_rate' =>44100, 'datetime_with_offset' =>"2010-10-13T00:00:00.000+10:00", 'original_format' =>".MP3", 'window' =>512, 'window_function' =>"Hamming", 'colour' =>"g"}}
+
+      fake_redis.set('baw-workers:test_get', payload.to_json)
+
+      response = redis.get('test_get')
+
+      expect(response).to eq(payload)
+    end
+
+    it 'wraps the GET command - for missing keys' do
+      response = redis.get('a-key-that-does-not-exist')
+
+      expect(response).to eq(nil)
+    end
+
+    it 'handles empty values' do
+      set_success = redis.set('test_empty', nil)
+      response = redis.get('test_empty')
+
+      expect(set_success).to eq(true)
+      expect(response).to be_nil
+
+      set_success = redis.set('test_empty', '')
+      response = redis.get('test_empty')
+
+      expect(set_success).to eq(true)
+      expect(response).to eq('')
+    end
+
+    it 'wraps the DEL command' do
+      fake_redis.set('baw-workers:my_object', '{"test":{"nested_hash":123},"string":"test"}')
+
+      expect(redis.delete('my_object')).to eq(true)
+      expect(fake_redis.exists('baw-workers:my_object')).to eq(false)
+    end
+
+    it 'wraps the EXISTS command' do
+      fake_redis.set('baw-workers:my_object', '{"test":{"nested_hash":123},"string":"test"}')
+
+      expect(redis.exists('my_object')).to eq(true)
+    end
+
+  end
+end

--- a/spec/lib/baw-workers/resque_status_spec.rb
+++ b/spec/lib/baw-workers/resque_status_spec.rb
@@ -1,0 +1,157 @@
+require 'spec_helper'
+
+describe 'Resque::Plugins::Status' do
+  include_context 'shared_test_helpers'
+
+  # We had a bug were configs were not initializing expire_in for resque status.
+  # This test ensures that it is set.
+  # These tests also test the monkey patch in `resque_status_custom_expire.rb` exists
+  context 'expire_in tests' do
+
+    it 'ensures expire_in is set for worker init' do
+      # run is called in the test initialization in `spec_helper.rb`
+
+      expect(Resque::Plugins::Status::Hash.expire_in).to eq(86400)
+    end
+
+
+    it 'ensures expire_in is set for worker init' do
+      # clear settings loaded in spec helper
+      reset_settings
+
+      expect(Resque::Plugins::Status::Hash.expire_in).to eq(nil)
+
+      BawWorkers::Config.run_web(
+          BawWorkers::MultiLogger.new,
+          BawWorkers::MultiLogger.new,
+          BawWorkers::MultiLogger.new,
+          BawWorkers::MultiLogger.new,
+          BawWorkers::Settings,
+          true)
+
+      expect(Resque::Plugins::Status::Hash.expire_in).to eq(86400)
+    end
+
+    it 'ensures our monkey patch exists' do
+      expect(Resque::Plugins::Status::EXPIRE_STATUSES).to eq([
+                                                                 'completed',
+                                                                 'failed',
+                                                                 'killed',
+                                                             ])
+    end
+
+    # Our monkey patch override the default TTL behaviour.
+    # Normally the TTL is reset every status change.
+    # Out patch makes sure the TTL is only set when a finished status has occurred.
+    it 'ensures a TTL is in fact set on a resque:status key only after it has completed ' do
+      # This is a just a copy of of a generic mirror test.
+      # We are just interjecting a few extra assertions during the different stages of  the job to make sure
+      # the resque:status keys are behaving as desired.
+
+      # setup
+      queue_name = 'template_default'
+
+      payload = {test_payload: 'a value'}
+      payload_wrapped = {template_params: {test_payload: 'a value'}}
+      payload_normalised = BawWorkers::ResqueJobId.normalise(payload_wrapped)
+
+      # check before
+      expect(Resque.size(queue_name)).to eq(0)
+      expect(BawWorkers::ResqueApi.job_queued?(BawWorkers::Template::Action, payload)).to eq(false)
+      expect(Resque.enqueued?(BawWorkers::Template::Action, payload)).to eq(false)
+
+      # queue and check
+      result1 = BawWorkers::Template::Action.action_enqueue(payload)
+      expect(Resque.size(queue_name)).to eq(1)
+      expect(result1).to be_a(String)
+      expect(result1.size).to eq(32)
+      expect(BawWorkers::ResqueApi.job_queued?(BawWorkers::Template::Action, payload_wrapped)).to eq(true)
+      expect(Resque.enqueued?(BawWorkers::Template::Action, payload_wrapped)).to eq(true)
+
+      found = BawWorkers::ResqueApi.jobs_of_with(BawWorkers::Template::Action, payload_wrapped)
+      job_id = BawWorkers::ResqueJobId.create_id_props(BawWorkers::Template::Action, payload_wrapped)
+
+      # check the contents of the resque payload
+      expect(found.size).to eq(1)
+      expect(found[0]['class']).to eq(BawWorkers::Template::Action.to_s)
+      expect(found[0]['queue']).to eq(queue_name)
+      expect(found[0]['args'].size).to eq(2)
+      expect(found[0]['args'][0]).to eq(job_id)
+      expect(found[0]['args'][1]).to eq(payload_normalised)
+
+      expect(job_id).to_not be_nil
+
+      # get status, ensure ttl is -1
+      status = BawWorkers::ResqueApi.status_by_key(result1)
+      expect(status.status).to eq('queued')
+      expect(status.uuid).to eq(job_id)
+      expect(status.options).to eq(payload_normalised)
+      expect(BawWorkers::ResqueApi.status_ttl(result1)).to eq (-1)
+
+      # dequeue and run the job
+      was_run = emulate_resque_worker(BawWorkers::Template::Action.queue)
+      expect(was_run).to eq(true)
+
+      # should also be able to retrieve status by uuid
+      status = BawWorkers::ResqueApi.status_by_key(result1)
+
+      expect(status).to_not be_nil
+      expect(status.status).to eq('completed')
+      expect(status.uuid).to eq(job_id)
+      expect(status.uuid).to eq(result1)
+      expect(status.options).to eq(payload_normalised)
+      expect(BawWorkers::ResqueApi.status_ttl(result1)).to eq(86400)
+    end
+  end
+
+  # Tests that sensible names are part our base action's definition.
+  # See https://github.com/QutBioacoustics/baw-workers/issues/41
+  context 'sensible names' do
+
+    it 'ensures action base has a name method that throws' do
+      new_base = BawWorkers::ActionBase.new('imtotesauuidbro', {im_an_option: :options!})
+
+      expect {
+        new_base.name
+      }.to raise_error(NotImplementedError)
+    end
+
+
+    it 'allows for empty names' do
+      allow_any_instance_of(BawWorkers::Template::Action).to receive(:name).and_return(nil)
+      payload = {im_an_option: :options!}
+
+      unique_key = BawWorkers::Template::Action.action_enqueue(payload)
+      was_run = emulate_resque_worker(BawWorkers::Template::Action.queue)
+      status = BawWorkers::ResqueApi.status_by_key(unique_key)
+
+      expect(status.name).to eq(nil)
+    end
+
+    it 'allows for duplicate names' do
+      allow_any_instance_of(BawWorkers::Template::Action).to receive(:name).and_return('same_name')
+
+      (1..2).each do |index|
+        # technically a different job so resque solo should not complain
+        payload = {im_an_option: index}
+
+        unique_key = BawWorkers::Template::Action.action_enqueue(payload)
+        was_run = emulate_resque_worker(BawWorkers::Template::Action.queue)
+        status = BawWorkers::ResqueApi.status_by_key(unique_key)
+
+        expect(status.name).to eq('same_name')
+      end
+    end
+
+    it 'names can reuse the uuid' do
+      payload = {im_an_option: :options!}
+
+      unique_key = BawWorkers::Template::Action.action_enqueue(payload)
+      was_run = emulate_resque_worker(BawWorkers::Template::Action.queue)
+      status = BawWorkers::ResqueApi.status_by_key(unique_key)
+
+      expect(status.name).to eq('template:' + unique_key)
+    end
+
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,14 +18,14 @@ if ENV['TRAVIS']
   end
   CodeClimate::TestReporter.start
 
-  SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
+  SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new(
       CodeClimate::TestReporter::Formatter
-  ]
+  )
 
 else
-  SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
+  SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new(
       SimpleCov::Formatter::HTMLFormatter
-  ]
+  )
 end
 
 # start code coverage
@@ -76,6 +76,10 @@ def reset_settings
 
   touch_path = %x(which touch).strip
   FileUtils.cp(touch_path, File.join(tmp_programs_dir,'touch'))
+
+  # reset in memory settings
+  BawWorkers::Config.instance_variables.map { |ivar| BawWorkers::Config.instance_variable_set(ivar, nil)}
+  Resque::Plugins::Status::Hash.expire_in = nil
 
   [tmp_logs_dir, custom_dir]
 end


### PR DESCRIPTION
Fixes #40. Fixes #41. Closes #31.

- Monkey patches resque:status so that TTLs are only set on finished
status
- Ensures resque:status's expire_in option is set for both work and web
startup scenarios
- Forces action implementers to override resque:status' default name
implementation to prevent double encoding of payloads
- Added friendly name methods to all actions
- Introduces the concept of partial payloads (splitting payloads into
variant and invariant parts) to reduce memory usage for large sets of
similar jobs
- It adapts the Analysis action (only) to use partial payloads. Users of
`action_enqueue` need to provide a group key to take advantage of the
functionality.
- We introduce our own Redis communicator for access to Redis outside of
Resque's scope
- It drys up the `config.rb` a bit.
- We add a template action as clean base (mainly done to help @atruskie
learn what is necessary for an Action to implement and what among the
other examples was extraneous to a minimal example).

:grinning: