### PR TITLE
Patch for resque formatter bug - attempt 2

### DIFF
--- a/baw-workers.gemspec
+++ b/baw-workers.gemspec
@@ -33,7 +33,10 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'fakeredis', '~> 0.5'
 
   # runtime dependencies
-  spec.add_runtime_dependency 'resque', '~> 1.25'
+
+  # Resque is hard locked to 1.25.2 because 1.26 has a breaking change with the loggers. When below lands when can bump version.
+  # https://github.com/resque/resque/commit/eaaac2acc209456cdd0dd794d2d3714968cf76e4
+  spec.add_runtime_dependency 'resque', '1.25.2'
   spec.add_runtime_dependency 'settingslogic', '~> 2.0'
   spec.add_runtime_dependency 'activesupport', '~> 4.2'
   spec.add_runtime_dependency 'resque_solo', '~> 0.1'

--- a/lib/baw-workers/config.rb
+++ b/lib/baw-workers/config.rb
@@ -211,14 +211,16 @@ module BawWorkers
             }
         }
 
-        # temporary hack - for some reason Resque overrides our default formatter. This is a new behaviour that I
-        # can't replicate in a dev environment. The formatter resque uses is the QuietFormatter and it literally just
+        # temporary hack - v1.26 of Resque overrides our default formatter.
+        # This is the fix for the bug https://github.com/resque/resque/commit/eaaac2acc209456cdd0dd794d2d3714968cf76e4
+        # This is a new behaviour that I can't replicate in a dev environment - which I now suspect is because we call .verbose somewhere.
+        # The formatter resque uses is the QuietFormatter and it literally just
         # writes out an empty string whenever a log statement is run. As near as I can tell this overwrite happens
         # either in Resque.info or one of the other Resque related functions in the result block above.
+        # It is also happens when workers are created which means patching the formatter below wouldn't work properly.
+        # Now instead of patching, just don't even start - fail fast!
         unless BawWorkers::Config.logger_worker.formatter.is_a?(BawWorkers::MultiLogger::CustomFormatter)
-          BawWorkers::Config.logger_worker.formatter = BawWorkers::MultiLogger::CustomFormatter.new
-
-          BawWorkers::Config.logger_worker.warn('BawWorkers::Config') { "Resque overwrote the default formatter!" }
+          fail "Resque overwrote the default formatter!"
         end
 
         BawWorkers::Config.logger_worker.warn('BawWorkers::Config') { result.to_json }


### PR DESCRIPTION
Finally found the problem
https://github.com/resque/resque/commit/eaaac2acc209456cdd0dd794d2d3714968cf76e4

Fixed resque version to 1.25.2

Closes #46 