### PR TITLE
Allow more sample rates

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,5 +4,6 @@ source 'https://rubygems.org'
 gemspec
 
 # added here because gemspec doesn't support getting gems from urls
-gem 'baw-audio-tools', git: 'https://github.com/QutBioacoustics/baw-audio-tools.git', branch: :master, ref: 'd8b0f4e2796c0c5ba5c2356b029a4019a9db8002'
+gem 'baw-audio-tools', git: 'https://github.com/QutBioacoustics/baw-audio-tools.git', branch: :master, ref: '5ec1af05280e43b6827ddc71f50593c217b3e373'
+
 gem 'resque-job-stats', git: 'https://github.com/echannel/resque-job-stats.git', branch: :master, ref: '8932c036'

--- a/lib/baw-workers/storage/common.rb
+++ b/lib/baw-workers/storage/common.rb
@@ -151,8 +151,9 @@ module BawWorkers
         provided = validate_msg_provided(opts)
         fail ArgumentError, "#{validate_msg_base} sample_rate. #{provided}" unless opts.include? :sample_rate
 
-        unless BawAudioTools::AudioBase.valid_sample_rates.include?(opts[:sample_rate].to_i)
-          fail ArgumentError, "sample_rate must be in #{BawAudioTools::AudioBase.valid_sample_rates}: #{opts[:sample_rate]}. #{provided}"
+        # sample rate must be either the native sample rate or on the list of allowed sample rates
+        unless BawAudioTools::AudioBase.valid_sample_rates.include?(opts[:sample_rate].to_i) || opts[:sample_rate].to_i == opts[:original_sample_rate].to_i
+            fail ArgumentError, "sample_rate must be in #{BawAudioTools::AudioBase.valid_sample_rates} or the original sample rate of #{opts[:original_sample_rate]}: #{opts[:sample_rate]}. #{provided}"
         end
       end
 

--- a/lib/baw-workers/storage/common.rb
+++ b/lib/baw-workers/storage/common.rb
@@ -152,8 +152,9 @@ module BawWorkers
         fail ArgumentError, "#{validate_msg_base} sample_rate. #{provided}" unless opts.include? :sample_rate
 
         # sample rate must be either the native sample rate or on the list of allowed sample rates
-        unless BawAudioTools::AudioBase.valid_sample_rates.include?(opts[:sample_rate].to_i) || opts[:sample_rate].to_i == opts[:original_sample_rate].to_i
-            fail ArgumentError, "sample_rate must be in #{BawAudioTools::AudioBase.valid_sample_rates} or the original sample rate of #{opts[:original_sample_rate]}: #{opts[:sample_rate]}. #{provided}"
+        valid_sample_rates = BawAudioTools::AudioBase.valid_sample_rates(opts[:format], opts[:original_sample_rate])
+        unless valid_sample_rates.include?(opts[:sample_rate].to_i)
+            fail ArgumentError, "sample_rate (#{opts[:sample_rate]}) must be in #{valid_sample_rates}. #{provided}"
         end
       end
 

--- a/spec/lib/baw-workers/storage/spectrogram_cache_spec.rb
+++ b/spec/lib/baw-workers/storage/spectrogram_cache_spec.rb
@@ -50,6 +50,100 @@ describe BawWorkers::Storage::SpectrogramCache do
     ).to eq cached_spectrogram_file_name_given_parameters
   end
 
+  context 'checking validation of sample rate' do
+
+    let(:non_standard_sample_rate) { 2323 }
+    # file name with non-standard sample rate
+    let(:cached_spectrogram_file_name_given_parameters_nssr) { "#{uuid}_#{start_offset}_#{end_offset}_#{channel}_#{non_standard_sample_rate}_#{window}_#{window_function}_#{colour}.#{format_spectrogram}" }
+
+    it 'creates the correct name with non standard original sample rate' do
+
+      expect(
+          spectrogram_cache.file_name(
+              {
+                  uuid: uuid,
+                  start_offset: start_offset,
+                  end_offset: end_offset,
+                  channel: channel,
+                  sample_rate: non_standard_sample_rate,
+                  original_sample_rate: non_standard_sample_rate,
+                  window: window,
+                  colour: colour,
+                  window_function: window_function,
+                  format: format_spectrogram
+              }
+          )
+      ).to eq cached_spectrogram_file_name_given_parameters_nssr
+
+    end
+
+    it 'creates the correct name with non standard original sample rate and a standard requested sample rate' do
+
+      expect(
+          spectrogram_cache.file_name(
+              {
+                  uuid: uuid,
+                  start_offset: start_offset,
+                  end_offset: end_offset,
+                  channel: channel,
+                  sample_rate: sample_rate,
+                  original_sample_rate: non_standard_sample_rate,
+                  window: window,
+                  colour: colour,
+                  window_function: window_function,
+                  format: format_spectrogram
+              }
+          )
+      ).to eq cached_spectrogram_file_name_given_parameters
+
+    end
+
+    it 'fails validation with non-standard sample rate different from specified original sample rate' do
+
+      expect {
+        spectrogram_cache.file_name(
+            {
+                uuid: uuid,
+                start_offset: start_offset,
+                end_offset: end_offset,
+                channel: channel,
+                sample_rate: 75757,
+                original_sample_rate: 12345,
+                window: window,
+                colour: colour,
+                window_function: window_function,
+                format: format_spectrogram
+            }
+        )
+      }.to raise_error(ArgumentError)
+
+    end
+
+    it 'fails validation with non standard sample rate and original sample rate not supplied' do
+
+      expect {
+        spectrogram_cache.file_name(
+            {
+                uuid: uuid,
+                start_offset: start_offset,
+                end_offset: end_offset,
+                channel: channel,
+                sample_rate: 87,
+                window: window,
+                colour: colour,
+                window_function: window_function,
+                format: format_spectrogram
+            }
+        )
+      }.to raise_error(ArgumentError)
+
+    end
+
+  end
+
+
+
+
   it 'creates the correct partial path' do
     expect(spectrogram_cache.partial_path(opts)).to eq partial_path
   end


### PR DESCRIPTION
Fixes #61
Associated with 
QutEcoacoustics/baw-audio-tools@5ec1af05280e43b6827ddc71f50593c217b3e373
QutEcoacoustics/baw-server#351
QutEcoacoustics/baw-server#343

Updated to use the valid_sample_rates method from baw-audio-tools that allows specification of format and original sample rate. 